### PR TITLE
Added support for colors in Geojson layers + Option to use free map tiles

### DIFF
--- a/src/ProjectionMapping/ProjectionDeckMap/layers.js
+++ b/src/ProjectionMapping/ProjectionDeckMap/layers.js
@@ -38,8 +38,20 @@ export const createGeoJsonLayer = (i, layer, GEOGRID) =>
     extruded: true,
     lineWidthScale: 20,
     lineWidthMinPixels: 2,
-    getLineColor: [255, 255, 255],
-    getFillColor: [200, 200, 200],
+    getLineColor: f => {
+      const hex = f.properties.color;
+      if (!hex) return [0, 0, 0];
+    
+      const rgba = hex.match(/[0-9a-f]{2}/gi).map(x => parseInt(x, 16));
+      return rgba.length === 4 ? rgba : rgba.slice(0, 3);
+    },
+    getFillColor: f => {
+      const hex = f.properties.color;
+      if (!hex) return [0, 0, 0];
+    
+      const rgba = hex.match(/[0-9a-f]{2}/gi).map(x => parseInt(x, 16));
+      return rgba.length === 4 ? rgba : rgba.slice(0, 3);
+    },
     getRadius: 100,
     getLineWidth: 1,
     getElevation: 30,
@@ -49,14 +61,15 @@ export const createGeoJsonLayer = (i, layer, GEOGRID) =>
     },
   });
 
+const isFreeMapEnabled = new URLSearchParams(window.location.search).get("usefreemap") === "true";
 export const createTileLayer = (mapStyle) =>
   new TileLayer({
     id: "sat-view-layer",
     data:
-      mapStyle &&
-      `https://api.mapbox.com/styles/v1/relnox/${mapStyle}/tiles/256/{z}/{x}/{y}?access_token=` +
-        process.env.REACT_APP_MAPBOX_TOKEN +
-        "&attribution=false&logo=false&fresh=true",
+      isFreeMapEnabled
+      ? "https://tiles.stadiamaps.com/tiles/stamen_toner/{z}/{x}/{y}@2x.png"
+      : mapStyle &&
+        `https://api.mapbox.com/styles/v1/relnox/${mapStyle}/tiles/256/{z}/{x}/{y}?access_token=${process.env.REACT_APP_MAPBOX_TOKEN}&attribution=false&logo=false&fresh=true`,
     minZoom: 0,
     maxZoom: 21,
     tileSize: 256,

--- a/src/ProjectionMapping/ProjectionDeckMap/layers.js
+++ b/src/ProjectionMapping/ProjectionDeckMap/layers.js
@@ -7,6 +7,16 @@ import { ArcLayer } from "@deck.gl/layers";
 import { CubeGeometry } from "@luma.gl/core";
 import { TextLayer } from "@deck.gl/layers";
 
+/**
+ * Converts a hex string to a RGB or RGBA array
+ * @param {string} hex - The 6 or 8 char hex to convert
+ * @returns {number[]} - Array of 3 RGB or 4 RGBA numbers
+ */
+function hex_to_rgba(hex) {
+  const rgba = hex.match(/[0-9a-f]{2}/gi).map(x => parseInt(x, 16));
+  return rgba.length === 4 ? rgba : rgba.slice(0, 3);
+}
+
 export const createHeatmapLayer = (i, layer, GEOGRID) =>
   new HeatmapLayer({
     id: `heatmap-layer-${i}`,
@@ -39,18 +49,16 @@ export const createGeoJsonLayer = (i, layer, GEOGRID) =>
     lineWidthScale: 20,
     lineWidthMinPixels: 2,
     getLineColor: f => {
-      const hex = f.properties.color;
+      const hex = f.properties.lineColor ?? f.properties.color;
       if (!hex) return [0, 0, 0];
     
-      const rgba = hex.match(/[0-9a-f]{2}/gi).map(x => parseInt(x, 16));
-      return rgba.length === 4 ? rgba : rgba.slice(0, 3);
+      return hex_to_rgba(hex);
     },
     getFillColor: f => {
-      const hex = f.properties.color;
+      const hex = f.properties.fillColor ?? f.properties.color;
       if (!hex) return [0, 0, 0];
     
-      const rgba = hex.match(/[0-9a-f]{2}/gi).map(x => parseInt(x, 16));
-      return rgba.length === 4 ? rgba : rgba.slice(0, 3);
+      return hex_to_rgba(hex);
     },
     getRadius: 100,
     getLineWidth: 1,
@@ -61,15 +69,14 @@ export const createGeoJsonLayer = (i, layer, GEOGRID) =>
     },
   });
 
-const isFreeMapEnabled = new URLSearchParams(window.location.search).get("usefreemap") === "true";
 export const createTileLayer = (mapStyle) =>
   new TileLayer({
     id: "sat-view-layer",
     data:
-      isFreeMapEnabled
-      ? "https://tiles.stadiamaps.com/tiles/stamen_toner/{z}/{x}/{y}@2x.png"
-      : mapStyle &&
-        `https://api.mapbox.com/styles/v1/relnox/${mapStyle}/tiles/256/{z}/{x}/{y}?access_token=${process.env.REACT_APP_MAPBOX_TOKEN}&attribution=false&logo=false&fresh=true`,
+      mapStyle &&
+      `https://api.mapbox.com/styles/v1/relnox/${mapStyle}/tiles/256/{z}/{x}/{y}?access_token=` +
+        process.env.REACT_APP_MAPBOX_TOKEN +
+        "&attribution=false&logo=false&fresh=true",
     minZoom: 0,
     maxZoom: 21,
     tileSize: 256,


### PR DESCRIPTION
Added support for colors inside geojson layers. If a geojson layer now has properties.color defined for a feature, that color will be used. The format is either a 6 or 8 digit hex.

Also made it so that if the usefreemap=true query parameter is present, the tilelayer will use a free map instead of the default one. This is usefull if anybody wants to run it localy or if the mapbox token changes